### PR TITLE
- #7 issue fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ FFmpeg Android runs on the following architectures:
 
 	```
 	dependencies {
-		implementation 'com.github.SimformSolutionsPvtLtd:SSffmpegVideoOperation:1.0.3'
+		implementation 'com.github.SimformSolutionsPvtLtd:SSffmpegVideoOperation:1.0.4'
 	}
 	```
 

--- a/SSffmpegVideoOperation/src/main/java/com/simform/videooperations/CallBackOfQuery.kt
+++ b/SSffmpegVideoOperation/src/main/java/com/simform/videooperations/CallBackOfQuery.kt
@@ -22,6 +22,18 @@ object CallBackOfQuery {
         gate.await()
     }
 
+    fun cancelProcess(executionId: Long) {
+        if (!executionId.equals(0)) {
+            FFmpeg.cancel(executionId)
+        } else {
+            FFmpeg.cancel()
+        }
+    }
+
+    fun cancelProcess() {
+        FFmpeg.cancel()
+    }
+
     private fun process(context: AppCompatActivity, query: Array<String>, ffmpegCallBack: FFmpegCallBack) {
         Config.enableLogCallback { logMessage ->
             val logs = LogMessage(logMessage.executionId, logMessage.level, logMessage.text)


### PR DESCRIPTION
- #7 issue fixed
Now any can cancel the FFMPEG process using CallBackOfQuery.cancelProcess(executionId) and CallBackOfQuery.cancelProcess()