### PR TITLE
Removing Activity Dependency from CallBackQuery callQuery

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/SSffmpegVideoOperation/build.gradle
+++ b/SSffmpegVideoOperation/build.gradle
@@ -12,7 +12,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.simform.videooperations'
                 artifactId = 'videooperations'
-                version = '1.0.7'
+                version = '1.0.8'
             }
         }
     }

--- a/SSffmpegVideoOperation/src/main/java/com/simform/videooperations/CallBackOfQuery.kt
+++ b/SSffmpegVideoOperation/src/main/java/com/simform/videooperations/CallBackOfQuery.kt
@@ -3,7 +3,6 @@ package com.simform.videooperations
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import androidx.appcompat.app.AppCompatActivity
 import com.arthenica.mobileffmpeg.Config
 import com.arthenica.mobileffmpeg.FFmpeg
 import java.util.concurrent.CyclicBarrier
@@ -12,10 +11,7 @@ import java.util.concurrent.CyclicBarrier
  * Created by Ashvin Vavaliya on 22,January,2021
  * Simform Solutions Pvt Ltd.
  */
-public class CallBackOfQuery {
-
-
-
+class CallBackOfQuery {
 
     fun callQuery(query: Array<String>, fFmpegCallBack: FFmpegCallBack) {
         val gate = CyclicBarrier(2)
@@ -41,15 +37,15 @@ public class CallBackOfQuery {
     }
 
     private fun process(query: Array<String>, ffmpegCallBack: FFmpegCallBack) {
-        val querylooper = Handler(Looper.getMainLooper())
+        val processHandler = Handler(Looper.getMainLooper())
         Config.enableLogCallback { logMessage ->
-            querylooper.post {
+            processHandler.post {
                 val logs = LogMessage(logMessage.executionId, logMessage.level, logMessage.text)
                 ffmpegCallBack.process(logs)
             }
         }
         Config.enableStatisticsCallback { statistics ->
-            querylooper.post {
+            processHandler.post {
                 val statisticsLog =
                     Statistics(statistics.executionId, statistics.videoFrameNumber, statistics.videoFps, statistics.videoQuality, statistics.size, statistics.time, statistics.bitrate, statistics.speed)
                 ffmpegCallBack.statisticsProcess(statisticsLog)
@@ -57,18 +53,18 @@ public class CallBackOfQuery {
         }
         when (FFmpeg.execute(query)) {
             Config.RETURN_CODE_SUCCESS -> {
-                querylooper.post {
+                processHandler.post {
                     ffmpegCallBack.success()
                 }
             }
             Config.RETURN_CODE_CANCEL -> {
-                querylooper.post{
+                processHandler.post{
                     ffmpegCallBack.cancel()
                     FFmpeg.cancel()
                 }
             }
             else -> {
-                querylooper.post{
+                processHandler.post{
                     ffmpegCallBack.failed()
                     Config.printLastCommandOutput(Log.INFO)
                 }

--- a/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/AudiosMergeActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/AudiosMergeActivity.kt
@@ -57,7 +57,7 @@ class AudiosMergeActivity : BaseActivity(R.layout.activity_audios_merge, R.strin
 
             val query = ffmpegQueryExtension.mergeAudios(pathsList, DURATION_FIRST, outputPath)
 
-            CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+            CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
                 override fun process(logMessage: LogMessage) {
                     tvOutputPath.text = logMessage.text
                 }

--- a/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/ChangeAudioVolumeActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/ChangeAudioVolumeActivity.kt
@@ -45,7 +45,7 @@ class ChangeAudioVolumeActivity : BaseActivity(R.layout.activity_change_audio_va
     private fun mergeAudioProcess() {
         val outputPath = Common.getFilePath(this, Common.MP3)
         val query = ffmpegQueryExtension.audioVolumeUpdate(tvInputPathAudio.text.toString(), volume = 0.1f, output = outputPath)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/CompressAudioActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/CompressAudioActivity.kt
@@ -46,7 +46,7 @@ class CompressAudioActivity : BaseActivity(R.layout.activity_compress_audio, R.s
     private fun compressAudioProcess() {
         val outputPath = Common.getFilePath(this, Common.MP3)
         val query = ffmpegQueryExtension.compressAudio(inputAudioPath = tvInputPathAudio.text.toString(), bitrate = BITRATE_128, output = outputPath)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/CropAudioActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/CropAudioActivity.kt
@@ -147,7 +147,7 @@ class CropAudioActivity : BaseActivity(R.layout.activity_crop_audio, R.string.cr
     private fun cutProcess() {
         val outputPath = Common.getFilePath(this, Common.MP3)
         val query = ffmpegQueryExtension.cutAudio(tvInputPath.text.toString(), startTimeString, endTimeString, outputPath)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/FastAndSlowAudioActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/FastAndSlowAudioActivity.kt
@@ -50,7 +50,7 @@ class FastAndSlowAudioActivity : BaseActivity(R.layout.activity_fast_and_slow_au
             atempo = 0.5
         }
         val query = ffmpegQueryExtension.audioMotion(tvInputPathAudio.text.toString(), outputPath, atempo)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/MergeGIFActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/otherFFMPEGProcessActivity/MergeGIFActivity.kt
@@ -109,7 +109,7 @@ class MergeGIFActivity : BaseActivity(R.layout.activity_merge_gif, R.string.merg
             }
             val query = ffmpegQueryExtension.mergeGIF(pathsList, xPos, yPos, widthScale, heightScale, outputPath)
 
-            CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+            CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
                 override fun process(logMessage: LogMessage) {
                     tvOutputPath.text = logMessage.text
                 }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/AddTextOnVideoActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/AddTextOnVideoActivity.kt
@@ -75,7 +75,7 @@ class AddTextOnVideoActivity : BaseActivity(R.layout.activity_add_text_on_video,
         }
         val fontPath = getFileFromAssets(this, "little_lord.ttf").absolutePath
         val query = ffmpegQueryExtension.addTextOnVideo(tvInputPathVideo.text.toString(), edtText.text.toString(), xPos, yPos, fontPath = fontPath, isTextBackgroundDisplay = true, fontSize = 28, fontcolor = "red", output = outputPath)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/AddWaterMarkOnVideoActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/AddWaterMarkOnVideoActivity.kt
@@ -110,7 +110,7 @@ class AddWaterMarkOnVideoActivity : BaseActivity(R.layout.activity_add_water_mar
             (edtYPos.text.toString().toFloat().times(it)).div(100)
         }
         val query = ffmpegQueryExtension.addVideoWaterMark(tvInputPathVideo.text.toString(), tvInputPathImage.text.toString(), xPos, yPos, outputPath)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/AspectRatioActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/AspectRatioActivity.kt
@@ -48,7 +48,7 @@ class AspectRatioActivity : BaseActivity(R.layout.activity_aspect_ratio, R.strin
         val outputPath = Common.getFilePath(this, Common.VIDEO)
         val query = ffmpegQueryExtension.applyRatio(tvInputPathVideo.text.toString(), RATIO_1, outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CombineImageAndVideoActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CombineImageAndVideoActivity.kt
@@ -107,7 +107,7 @@ class CombineImageAndVideoActivity : BaseActivity(R.layout.activity_merge_image_
 
         val query = ffmpegQueryExtension.combineImagesAndVideos(paths, width, height, edtSecond.text.toString(), outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CombineImagesActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CombineImagesActivity.kt
@@ -91,7 +91,7 @@ class CombineImagesActivity : BaseActivity(R.layout.activity_combine_images, R.s
 
             val query = ffmpegQueryExtension.combineImagesAndVideos(pathsList, 640, 480, edtSecond.text.toString(), outputPath)
 
-            CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+            CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
                 override fun process(logMessage: LogMessage) {
                     tvOutputPath.text = logMessage.text
                 }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CombineVideosActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CombineVideosActivity.kt
@@ -103,7 +103,7 @@ class CombineVideosActivity : BaseActivity(R.layout.activity_combine_videos, R.s
                 height,
                 outputPath
             )
-            CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+            CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
                 override fun process(logMessage: LogMessage) {
                     tvOutputPath.text = logMessage.text
                 }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CompressVideoActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CompressVideoActivity.kt
@@ -10,7 +10,6 @@ import com.simform.videoimageeditor.R
 import com.simform.videooperations.CallBackOfQuery
 import com.simform.videooperations.Common
 import com.simform.videooperations.FFmpegCallBack
-import com.simform.videooperations.FFmpegQueryExtension
 import com.simform.videooperations.LogMessage
 import java.io.File
 import java.util.concurrent.CompletableFuture
@@ -72,13 +71,12 @@ class CompressVideoActivity : BaseActivity(R.layout.activity_compress_video, R.s
 
     private fun compressProcess() {
         val outputPath = Common.getFilePath(this, Common.VIDEO)
-        val query = ffmpegQueryExtension.compressor(tvInputPathVideo.text.toString(), width, height, outputPath)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        val query = ffmpegQueryExtension.compressorH264(tvInputPathVideo.text.toString(), width, height, outputPath)
+        CallBackOfQuery().callQuery( query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }
 
-            @SuppressLint("SetTextI18n")
             override fun success() {
                 tvOutputPath.text = String.format(getString(R.string.output_path_with_size), outputPath, Common.getFileSize(File(outputPath)))
                 processStop()
@@ -95,11 +93,9 @@ class CompressVideoActivity : BaseActivity(R.layout.activity_compress_video, R.s
     }
 
     private fun processStop() {
-        runOnUiThread {
             btnVideoPath.isEnabled = true
             btnCompress.isEnabled = true
-            mProgressView.visibility = View.GONE
-        }
+        mProgressView.visibility = View.GONE
     }
 
     private fun processStart() {

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CutVideoUsingTimeActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/CutVideoUsingTimeActivity.kt
@@ -150,7 +150,7 @@ class CutVideoUsingTimeActivity : BaseActivity(R.layout.activity_cut_video_using
     private fun cutProcess() {
         val outputPath = Common.getFilePath(this, Common.VIDEO)
         val query = ffmpegQueryExtension.cutVideo(tvInputPath.text.toString(), startTimeString, endTimeString, outputPath)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/ExtractAudioActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/ExtractAudioActivity.kt
@@ -46,7 +46,7 @@ class ExtractAudioActivity : BaseActivity(R.layout.activity_extract_audio, R.str
         val outputPath = Common.getFilePath(this, Common.MP3)
         val query = ffmpegQueryExtension.extractAudio(tvInputPathVideo.text.toString(), outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/ExtractImagesActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/ExtractImagesActivity.kt
@@ -63,7 +63,7 @@ class ExtractImagesActivity : BaseActivity(R.layout.activity_extract_images, R.s
         val outputPath = Common.getFilePath(this, Common.IMAGE)
         val query = ffmpegQueryExtension.extractImages(tvInputPathVideo.text.toString(), outputPath, spaceOfFrame = 4f)
         var totalFramesExtracted = 0
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun statisticsProcess(statistics: Statistics) {
                 totalFramesExtracted = statistics.videoFrameNumber
                 tvOutputPath.text = "Frames : ${statistics.videoFrameNumber}"

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/FastAndSlowVideoMotionActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/FastAndSlowVideoMotionActivity.kt
@@ -52,7 +52,7 @@ class FastAndSlowVideoMotionActivity : BaseActivity(R.layout.activity_fast_and_s
             atempo = 0.5
         }
         val query = ffmpegQueryExtension.videoMotion(tvInputPathVideo.text.toString(), outputPath, setpts, atempo)
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/ImageToVideoConvertActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/ImageToVideoConvertActivity.kt
@@ -68,7 +68,7 @@ class ImageToVideoConvertActivity : BaseActivity(R.layout.activity_image_to_vide
         val size: ISize = SizeOfImage(tvInputPath.text.toString())
         val query = ffmpegQueryExtension.imageToVideo(tvInputPath.text.toString(), outputPath, edtSecond.text.toString().toInt(), size.width(), size.height())
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/MergeAudioVideoActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/MergeAudioVideoActivity.kt
@@ -56,7 +56,7 @@ class MergeAudioVideoActivity : BaseActivity(R.layout.activity_merge_audio_video
         val outputPath = Common.getFilePath(this, Common.VIDEO)
         val query = ffmpegQueryExtension.mergeAudioVideo(tvInputPathVideo.text.toString(), tvInputPathAudio.text.toString(), outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/MergeImageAndMP3Activity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/MergeImageAndMP3Activity.kt
@@ -56,7 +56,7 @@ class MergeImageAndMP3Activity : BaseActivity(R.layout.activity_merge_image_and_
         val outputPath = Common.getFilePath(this, Common.VIDEO)
         val query = ffmpegQueryExtension.mergeImageAndAudio(tvInputPathImage.text.toString(), tvInputPathAudio.text.toString(), outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/RemoveAudioFromVideoActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/RemoveAudioFromVideoActivity.kt
@@ -47,7 +47,7 @@ class RemoveAudioFromVideoActivity : BaseActivity(R.layout.activity_remove_audio
         val outputPath = Common.getFilePath(this, Common.VIDEO)
         val query = ffmpegQueryExtension.removeAudioFromVideo(tvInputPathVideo.text.toString(), outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/ReverseVideoActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/ReverseVideoActivity.kt
@@ -47,7 +47,7 @@ class ReverseVideoActivity : BaseActivity(R.layout.activity_reverse, R.string.re
         val outputPath = Common.getFilePath(this, Common.VIDEO)
         val query = ffmpegQueryExtension.videoReverse(tvInputPathVideo.text.toString(), isWithAudioSwitch.isChecked, outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/VideoFadeInFadeOutActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/VideoFadeInFadeOutActivity.kt
@@ -51,7 +51,7 @@ class VideoFadeInFadeOutActivity : BaseActivity(R.layout.activity_video_fade_in_
         val outputPath = Common.getFilePath(this, Common.VIDEO)
         val query = ffmpegQueryExtension.videoFadeInFadeOut(tvInputPathVideo.text.toString(), selectedVideoDurationInSecond, fadeInEndSeconds = 3, fadeOutStartSeconds = 3, output = outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/VideoRotateFlipActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/VideoRotateFlipActivity.kt
@@ -85,7 +85,7 @@ class VideoRotateFlipActivity : BaseActivity(R.layout.activity_video_rotate_flip
             ffmpegQueryExtension.flipVideo(tvInputPathVideo.text.toString(), degree, outputPath)
         }
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }

--- a/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/VideoToGifActivity.kt
+++ b/app/src/main/java/com/simform/videoimageeditor/videoProcessActivity/VideoToGifActivity.kt
@@ -48,7 +48,7 @@ class VideoToGifActivity : BaseActivity(R.layout.activity_video_to_gif, R.string
         val outputPath = Common.getFilePath(this, Common.GIF)
         val query = ffmpegQueryExtension.convertVideoToGIF(tvInputPathVideo.text.toString(), outputPath)
 
-        CallBackOfQuery().callQuery(this, query, object : FFmpegCallBack {
+        CallBackOfQuery().callQuery(query, object : FFmpegCallBack {
             override fun process(logMessage: LogMessage) {
                 tvOutputPath.text = logMessage.text
             }


### PR DESCRIPTION
By Creating a handler inside of the callQuery method you can remove the Activity Dependency from callQuery considering all you were doing was calling runOnUiThread in onSuccess. This is also better because now this can be called from a ViewModel without much issue.